### PR TITLE
Jest configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,10 @@
     "start": "webpack --watch",
     "build": "webpack"
   },
+  "jest": {
+    "verbose": true,
+    "testURL": "http://localhost/"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Aljullu/react-lazy-load-image-component.git"

--- a/package.json
+++ b/package.json
@@ -40,10 +40,6 @@
     "start": "webpack --watch",
     "build": "webpack"
   },
-  "jest": {
-    "verbose": true,
-    "testURL": "http://localhost/"
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Aljullu/react-lazy-load-image-component.git"

--- a/src/components/LazyLoadImage.jsx
+++ b/src/components/LazyLoadImage.jsx
@@ -101,26 +101,13 @@ class LazyLoadImage extends React.Component {
 
 LazyLoadImage.propTypes = {
   afterLoad: PropTypes.func,
-  beforeLoad: PropTypes.func,
-  delayMethod: PropTypes.string,
-  delayTime: PropTypes.number,
-  effect: PropTypes.string,
-  placeholderSrc: PropTypes.string,
-  threshold: PropTypes.number,
-  visibleByDefault: PropTypes.bool,
-  wrapperClassName: PropTypes.string
+  effect: PropTypes.string
 };
 
 LazyLoadImage.defaultProps = {
   afterLoad: () => ({}),
-  beforeLoad: () => ({}),
-  delayMethod: 'throttle',
-  delayTime: 300,
-  effect: '',
-  placeholderSrc: '',
-  threshold: 100,
-  visibleByDefault: false,
-  wrapperClassName: ''
+  effect: ''
 };
 
 export default LazyLoadImage;
+

--- a/src/components/LazyLoadImage.jsx
+++ b/src/components/LazyLoadImage.jsx
@@ -101,16 +101,26 @@ class LazyLoadImage extends React.Component {
 
 LazyLoadImage.propTypes = {
   afterLoad: PropTypes.func,
+  beforeLoad: PropTypes.func,
+  delayMethod: PropTypes.string,
+  delayTime: PropTypes.number,
   effect: PropTypes.string,
   placeholderSrc: PropTypes.string,
+  threshold: PropTypes.number,
+  visibleByDefault: PropTypes.bool,
   wrapperClassName: PropTypes.string
 };
 
 LazyLoadImage.defaultProps = {
   afterLoad: () => ({}),
-  wrapperClassName: '',
+  beforeLoad: () => ({}),
+  delayMethod: 'throttle',
+  delayTime: 300,
+  effect: '',
   placeholderSrc: '',
-  effect: ''
+  threshold: 100,
+  visibleByDefault: false,
+  wrapperClassName: ''
 };
 
 export default LazyLoadImage;

--- a/src/components/LazyLoadImage.jsx
+++ b/src/components/LazyLoadImage.jsx
@@ -102,11 +102,14 @@ class LazyLoadImage extends React.Component {
 LazyLoadImage.propTypes = {
   afterLoad: PropTypes.func,
   effect: PropTypes.string,
-  placeholderSrc: PropTypes.string
+  placeholderSrc: PropTypes.string,
+  wrapperClassName: PropTypes.string
 };
 
 LazyLoadImage.defaultProps = {
   afterLoad: () => ({}),
+  wrapperClassName: '',
+  placeholderSrc: '',
   effect: ''
 };
 

--- a/src/components/LazyLoadImage.spec.js
+++ b/src/components/LazyLoadImage.spec.js
@@ -25,7 +25,7 @@ describe('LazyLoadImage', function() {
       placeholder: null,
       scrollPosition: {x: 0, y: 0},
       style: {},
-      src: 'lorem-ipsum.jpg',
+      src: 'http://localhost/lorem-ipsum.jpg',
       visibleByDefault: false
     };
     const lazyLoadImage = mount(

--- a/src/components/LazyLoadImage.spec.js
+++ b/src/components/LazyLoadImage.spec.js
@@ -25,7 +25,7 @@ describe('LazyLoadImage', function() {
       placeholder: null,
       scrollPosition: {x: 0, y: 0},
       style: {},
-      src: 'http://localhost/lorem-ipsum.jpg',
+      src: 'lorem-ipsum.jpg',
       visibleByDefault: false
     };
     const lazyLoadImage = mount(


### PR DESCRIPTION
``` 
 ● Test suite failed to run
    SecurityError: localStorage is not available for opaque origins
      
      at Window.get localStorage [as localStorage] (node_modules/jsdom/lib/jsdom/browser/Window.js:257:15)
      at Array.forEach (native)
```

I saw this error message, So I looked for a way to fix this error and found this link and added testUrl to package.json.

jsdom/jsdom#2304