### PR TITLE
Fix Jest origin error

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,10 @@
     "start": "webpack --watch",
     "build": "webpack"
   },
+  "jest": {
+    "verbose": true,
+    "testURL": "http://localhost/"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Aljullu/react-lazy-load-image-component.git"

--- a/src/components/LazyLoadImage.spec.js
+++ b/src/components/LazyLoadImage.spec.js
@@ -25,7 +25,7 @@ describe('LazyLoadImage', function() {
       placeholder: null,
       scrollPosition: {x: 0, y: 0},
       style: {},
-      src: 'lorem-ipsum.jpg',
+      src: 'http://localhost/lorem-ipsum.jpg',
       visibleByDefault: false
     };
     const lazyLoadImage = mount(


### PR DESCRIPTION
Tests were returning `SecurityError: localStorage is not available for opaque origins` because of a configuration issue with Jest.

Supersedes #4.