### PR TITLE
Updated code to be universal. So it can be executed in node environment.

### DIFF
--- a/src/components/PlaceholderWithoutTracking.jsx
+++ b/src/components/PlaceholderWithoutTracking.jsx
@@ -32,7 +32,7 @@ class PlaceholderWithoutTracking extends React.Component {
   }
 
   isPlaceholderInViewport() {
-    if (!this.placeholder) {
+    if (typeof window === 'undefined' || !this.placeholder) {
       return false;
     }
 

--- a/src/hoc/trackWindowScroll.js
+++ b/src/hoc/trackWindowScroll.js
@@ -18,18 +18,30 @@ const trackWindowScroll = (BaseComponent) => {
 
       this.state = {
         scrollPosition: {
-          x: window.scrollX || window.pageXOffset,
-          y: window.scrollY || window.pageYOffset,
+          x: (typeof window === 'undefined' ?
+            0 :
+            (window.scrollX || window.pageXOffset)
+          ),
+          y: (typeof window === 'undefined' ?
+            0 :
+            (window.scrollY || window.pageYOffset)
+          ),
         },
       };
     }
 
     componentDidMount() {
+      if (typeof window == 'undefined') {
+        return;
+      }
       window.addEventListener('scroll', this.delayedScroll);
       window.addEventListener('resize', this.delayedScroll);
     }
 
     componentWillUnmount() {
+      if (typeof window === 'undefined') {
+        return;
+      }
       window.removeEventListener('scroll', this.delayedScroll);
       window.removeEventListener('resize', this.delayedScroll);
     }
@@ -37,8 +49,14 @@ const trackWindowScroll = (BaseComponent) => {
     onChangeScroll() {
       this.setState({
         scrollPosition: {
-          x: window.scrollX || window.pageXOffset,
-          y: window.scrollY || window.pageYOffset,
+          x: (typeof window == 'undefined' ?
+            0 :
+            (window.scrollX || window.pageXOffset)
+          ),
+          y: (typeof window === 'undefined' ?
+            0 :
+            (window.scrollY || window.pageYOffset)
+          ),
         },
       });
     }


### PR DESCRIPTION
This PR enables the image component to be executed on server side for SSR. Otherwise it throws following error.
```
ReferenceError: window is not defined
at new r (<path>/node_modules/react-lazy-load-image-component/build/index.js:1:7434)
...
```

Additionally we can use it with `visibleByDefault` option `visibleByDefault={typeof window === "undefined"}` to output image src tags from server rendered content.