### PR TITLE
fix(intersectionObs): guarding against undefined window

### DIFF
--- a/src/utils/intersection-observer.js
+++ b/src/utils/intersection-observer.js
@@ -1,5 +1,6 @@
 export default function() {
   return (
+    typeof window !== 'undefined' &&
     'IntersectionObserver' in window &&
     'isIntersecting' in window.IntersectionObserverEntry.prototype
   );


### PR DESCRIPTION
Fixes #21

**Description**
When running a server-side render of my site, I get a 'window is not defined' error thrown from `intersection-observer.js`. Adding a guard to ensure `window` is defined before checking for the presence of IntersectionObserver. 
