### PR TITLE
feat(hideImage): hide background image when full image has loaded

### DIFF
--- a/src/components/LazyLoadImage.jsx
+++ b/src/components/LazyLoadImage.jsx
@@ -71,8 +71,8 @@ class LazyLoadImage extends React.Component {
         className={wrapperClassName + ' lazy-load-image-background ' +
           effect + loadedClassName}
         style={{
-          backgroundImage: 'url( ' + placeholderSrc + ')',
-          backgroundSize: '100% 100%',
+          backgroundImage: loaded ? '' : 'url( ' + placeholderSrc + ')',
+          backgroundSize: loaded ? '' : '100% 100%',
           color: 'transparent',
           display: 'inline-block',
           height: height,


### PR DESCRIPTION
Fixes #19 

**Description**
Once the intended image has loaded, the placeholder/background image should no longer appear.