### PR TITLE
Bug fix

### DIFF
--- a/src/components/LazyLoadImage.jsx
+++ b/src/components/LazyLoadImage.jsx
@@ -73,8 +73,8 @@ class LazyLoadImage extends React.Component {
         className={wrapperClassName + ' lazy-load-image-background ' +
           effect + loadedClassName}
         style={{
-          backgroundImage: loaded || !placeholderSrc ? '' : 'url( ' + placeholderSrc + ')',
-          backgroundSize: loaded || !placeholderSrc ? '' : '100% 100%,
+          backgroundImage: loaded || !placeholderSrc ? '' : `url(${placeholderSrc})`,
+          backgroundSize: loaded || !placeholderSrc ? '' : '100% 100%',
           color: 'transparent',
           display: 'inline-block',
           height: height,

--- a/src/components/LazyLoadImage.jsx
+++ b/src/components/LazyLoadImage.jsx
@@ -73,8 +73,8 @@ class LazyLoadImage extends React.Component {
         className={wrapperClassName + ' lazy-load-image-background ' +
           effect + loadedClassName}
         style={{
-          backgroundImage: loaded ? '' : 'url( ' + placeholderSrc + ')',
-          backgroundSize: loaded ? '' : '100% 100%',
+          backgroundImage: loaded ? '' : (placeholderSrc ? 'url( ' + placeholderSrc + ')' : ''),
+          backgroundSize: loaded ? '' : (placeholderSrc ? '100% 100%' : ''),
           color: 'transparent',
           display: 'inline-block',
           height: height,
@@ -120,7 +120,7 @@ LazyLoadImage.defaultProps = {
   delayMethod: 'throttle',
   delayTime: 300,
   effect: '',
-  placeholderSrc: '',
+  placeholderSrc: null,
   threshold: 100,
   useIntersectionObserver: true,
   visibleByDefault: false,

--- a/src/components/LazyLoadImage.jsx
+++ b/src/components/LazyLoadImage.jsx
@@ -73,8 +73,8 @@ class LazyLoadImage extends React.Component {
         className={wrapperClassName + ' lazy-load-image-background ' +
           effect + loadedClassName}
         style={{
-          backgroundImage: loaded ? '' : (placeholderSrc ? 'url( ' + placeholderSrc + ')' : ''),
-          backgroundSize: loaded ? '' : (placeholderSrc ? '100% 100%' : ''),
+          backgroundImage: loaded || !placeholderSrc ? '' : 'url( ' + placeholderSrc + ')',
+          backgroundSize: loaded || !placeholderSrc ? '' : '100% 100%,
           color: 'transparent',
           display: 'inline-block',
           height: height,


### PR DESCRIPTION
Fixes #
instead of having empty string in background-image, don't have background-image at all instead when there is not placeholderSrc passed

**Description**
background-image: "", makes a network call to this empty URL, instead it should just not be there in the first place if it was not specified

So at the moment we have to do something like this, to avoid a network call being made to ""

```
      <LazyLoadImage
        alt={imageAlt}
        src={`https://asapcdn.com/resize/?w=366&h=233&pad=true&i=${imageSrc}`}
        height="auto"
        style={{
          maxWidth: '100%',
          maxHeight: maxHeight || ''
        }}
        visibleByDefault={!lazyLoad}
        effect="blur"
        placeholderSrc={
          'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=='
        }
      />
```

[https://imgur.com/a/E2O8zNQ](url) - screenshot

cc - @Aljullu 