### PR TITLE
Render image once to prevent double downloading

### DIFF
--- a/src/components/LazyLoadImage.jsx
+++ b/src/components/LazyLoadImage.jsx
@@ -122,10 +122,9 @@ class LazyLoadImage extends React.Component {
 
 	render() {
 		const { effect, placeholderSrc, visibleByDefault } = this.props;
-		const { loaded } = this.state;
 
 		const image = this.getImg();
-		const lazyLoadImage = loaded ? image : this.getLazyLoadImage(image);
+		const lazyLoadImage = this.getLazyLoadImage(image);
 
 		if ((!effect && !placeholderSrc) || visibleByDefault) {
 			return lazyLoadImage;


### PR DESCRIPTION
Fixes #50 

**Description**
Removed `loaded` state check in render method of `LazyLoadImage` component to prevent double image download in some browsers(Chrome). 
