### PR TITLE
Reuse the same IntersectionObserver for all components #25

### DIFF
--- a/src/components/LazyLoadComponent.spec.js
+++ b/src/components/LazyLoadComponent.spec.js
@@ -66,6 +66,7 @@ describe('LazyLoadComponent', function() {
 			isIntersectionObserverAvailable.mockImplementation(() => true);
 			window.IntersectionObserver = jest.fn(function() {
 				this.observe = jest.fn(); // eslint-disable-line babel/no-invalid-this
+				this.unobserve = jest.fn(); // eslint-disable-line babel/no-invalid-this
 			});
 
 			const lazyLoadComponent = mount(
@@ -93,6 +94,7 @@ describe('LazyLoadComponent', function() {
 			isIntersectionObserverAvailable.mockImplementation(() => true);
 			window.IntersectionObserver = jest.fn(function() {
 				this.observe = jest.fn(); // eslint-disable-line babel/no-invalid-this
+				this.unobserve = jest.fn(); // eslint-disable-line babel/no-invalid-this
 			});
 
 			const lazyLoadComponent = mount(

--- a/src/components/PlaceholderWithoutTracking.spec.js
+++ b/src/components/PlaceholderWithoutTracking.spec.js
@@ -197,6 +197,7 @@ describe('PlaceholderWithoutTracking', function() {
 		isIntersectionObserverAvailable.mockImplementation(() => true);
 		window.IntersectionObserver = jest.fn(function() {
 			this.observe = jest.fn(); // eslint-disable-line babel/no-invalid-this
+			this.unobserve = jest.fn(); // eslint-disable-line babel/no-invalid-this
 		});
 		const onVisible = jest.fn();
 		const component = renderPlaceholderWithoutTracking({
@@ -211,6 +212,7 @@ describe('PlaceholderWithoutTracking', function() {
 		isIntersectionObserverAvailable.mockImplementation(() => true);
 		window.IntersectionObserver = jest.fn(function() {
 			this.observe = jest.fn(); // eslint-disable-line babel/no-invalid-this
+			this.unobserve = jest.fn(); // eslint-disable-line babel/no-invalid-this
 		});
 		const offset = 100000;
 		const onVisible = jest.fn();


### PR DESCRIPTION
Fixes #
https://github.com/Aljullu/react-lazy-load-image-component/issues/25

**Description**
Minimizes the number of intersection observers created. Shares intersection observers between components that share the same threshold.
