### PR TITLE
Opacity effect: remove background-image property

### DIFF
--- a/src/effects/opacity.css
+++ b/src/effects/opacity.css
@@ -1,5 +1,4 @@
 .lazy-load-image-background.opacity {
-  background-image: none !important;
   opacity: 0;
 }
 


### PR DESCRIPTION
Fixes #65.

**Description**
The opacity effect CSS was setting `background-image: none !important`, but it can be removed to make it easier for consumers to add their own styles.
