### PR TITLE
Don't set placeholder text color to transparent

### DIFF
--- a/src/components/LazyLoadImage.jsx
+++ b/src/components/LazyLoadImage.jsx
@@ -111,7 +111,6 @@ class LazyLoadImage extends React.Component {
 							: `url(${placeholderSrc})`,
 					backgroundSize:
 						loaded || !placeholderSrc ? '' : '100% 100%',
-					color: 'transparent',
 					display: 'inline-block',
 					height: height,
 					width: width,


### PR DESCRIPTION
Fixes #63.

**Description**
Placeholders with text were not visible because we were forcing the text color to transparent.