### PR TITLE
Update peer dependencies to allow react v17

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
 	"description": " React Component to lazy load images using a HOC to track window scroll position. ",
 	"main": "build/index.js",
 	"peerDependencies": {
-		"react": "^15.x.x || ^16.x.x",
-		"react-dom": "^15.x.x || ^16.x.x"
+		"react": "^15.x.x || ^16.x.x || ^17.x.x",
+		"react-dom": "^15.x.x || ^16.x.x || ^17.x.x"
 	},
 	"dependencies": {
 		"lodash.debounce": "^4.0.8",


### PR DESCRIPTION
Installing **react-lazy-load-image-component** in a React v17 based project produces the following warnings:

```
warning " > react-lazy-load-image-component@1.5.0" has incorrect peer dependency "react@^15.x.x || ^16.x.x".
warning " > react-lazy-load-image-component@1.5.0" has incorrect peer dependency "react-dom@^15.x.x || ^16.x.x".
```

Since the react dev team postponed breaking changes to React v18 it is safe to update the peer dependencies.
