### PR TITLE
[patch] use forwardRef instead of ref

### DIFF
--- a/src/hoc/trackWindowScroll.js
+++ b/src/hoc/trackWindowScroll.js
@@ -124,7 +124,7 @@ const trackWindowScroll = BaseComponent => {
 
 			return (
 				<BaseComponent
-					ref={this.baseComponentRef}
+					forwardRef={this.baseComponentRef}
 					scrollPosition={scrollPosition}
 					{...props}
 				/>


### PR DESCRIPTION
 - this stops a warning being produced when testing which reads:
> Warning: Function components cannot be given refs. Attempts to access this ref will fail. Did you mean to use React.forwardRef()?
 - Fixes #67

**Description**
A clear and concise description of what this PR does.
Use the more modern forwardRef for which works for both functionComponents and old class components