### PR TITLE
Update peer dependencies to allow React 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
 	"description": " React Component to lazy load images using a HOC to track window scroll position.",
 	"main": "build/index.js",
 	"peerDependencies": {
-		"react": "^15.x.x || ^16.x.x || ^17.x.x",
-		"react-dom": "^15.x.x || ^16.x.x || ^17.x.x"
+		"react": "^15.x.x || ^16.x.x || ^17.x.x || ^18.x.x",
+		"react-dom": "^15.x.x || ^16.x.x || ^17.x.x || ^18.x.x"
 	},
 	"dependencies": {
 		"lodash.debounce": "^4.0.8",


### PR DESCRIPTION
Fixes #99

**Description**
Update peer dependencies to allow React 18