### PR TITLE
fix(intersection obs): handled edge case where component not visible

### DIFF
--- a/src/components/PlaceholderWithoutTracking.jsx
+++ b/src/components/PlaceholderWithoutTracking.jsx
@@ -51,7 +51,7 @@ class PlaceholderWithoutTracking extends React.Component {
 	}
 
 	componentWillUnmount() {
-		if (this.observer) {
+		if (this.observer && this.placeholder) {
 			this.observer.unobserve(this.placeholder);
 		}
 	}


### PR DESCRIPTION
Fixes #114 

**Description**
Adds sanity check similar to what `componentDidMount` does at `line 42` in `src/components/PlaceholderWithoutTracking.jsx` to avoid edge case which results in 

`Uncaught TypeError: IntersectionObserver.unobserve: Argument 1 is not an object.`

to occur.

@Aljullu 
